### PR TITLE
No longer needing minimum-stability: dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Composer will take care of installing the plugin into the correct location. Incl
 
 ```json
 {
-    "minimum-stability": "dev",
-    "config": {
-        "vendor-dir": "Vendor"
-    },
     "require": {
         "paulredmond/chosen-cakephp": "*"
     }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.2.6",
-        "composer/installers": "dev-master"
+        "composer/installers": "1.*"
     },
     "config": {
         "vendor-dir": "Vendor"


### PR DESCRIPTION
No longer requiring dev version of `composer/installers` for `installer-name` to work now.

Also removing `"vendor-dir": "Vendor"` as I think it should be case-insensitive.
